### PR TITLE
Add meeting minutes for April 13

### DIFF
--- a/TSC/meetings/minutes_2020_0413.md
+++ b/TSC/meetings/minutes_2020_0413.md
@@ -1,0 +1,19 @@
+# TSC Meeting Minutes - 03/30/2019
+**Attendees:**
+- [ ] John Mertic (JM)
+- [ ] Tatiana Balaburkina (TB)
+- [X] Giancarlo Frix (GF)
+- [ ] Joe Devlin (JD)
+- [X] Joe Bostian (JB)
+- [ ] Zach Burns (ZB)
+- [ ] Peter Fandel (PF)
+
+Additional Attendees: Salisu Ali
+
+## Agenda
+<none>
+
+## Minutes
+- (JB) Check up on the progress of gcc and glibc
+   - (GF) Projects are progressing.  Should have something that could be functional
+     by the end of this year


### PR DESCRIPTION
Signed-off-by: Joe Bostian <jbostian@us.ibm.com>

new file:   TSC/meetings/minutes_2020_0413.md